### PR TITLE
feat: Add in-scene NPCs and enhance dialogue interaction

### DIFF
--- a/test/game-interface-view.npcs-dialogues.test.js
+++ b/test/game-interface-view.npcs-dialogues.test.js
@@ -47,9 +47,46 @@ class MockGameInterfaceViewForDialogues {
     this._activeDialogueNpcId = null;
     this._currentDialogueNodeId = null;
     this._currentDialogueNode = null;
+    this._renderedInSceneNpcs = []; // For tracking NPCs that would be rendered in scene
 
     this.dispatchEvent = (event) => { this.dispatchedEvents.push({ type: event.type, detail: event.detail }); };
     this.requestUpdate = () => { /* console.log("MockGameInterfaceView: requestUpdate called for dialogue test"); */ };
+  }
+
+  setLocationData(locationData) {
+    this.locationData = locationData;
+    this._updateRenderedInSceneNpcs();
+  }
+
+  setAllNpcs(allNpcsMap) {
+    this.allNpcs = allNpcsMap;
+    this._updateRenderedInSceneNpcs();
+  }
+  
+  setAllDialogues(allDialogues) {
+    this.allDialogues = allDialogues;
+    // No need to update in-scene NPCs for dialogue changes
+  }
+
+  _updateRenderedInSceneNpcs() {
+    this._renderedInSceneNpcs = [];
+    if (this.locationData && !this.locationData.isMarket && this.locationData.npcIds && this.allNpcs) {
+      this.locationData.npcIds.forEach(npcId => {
+        const npc = this.allNpcs.get(npcId);
+        if (npc && npc.position && typeof npc.position.x === 'string' && typeof npc.position.y === 'string') {
+          this._renderedInSceneNpcs.push(npc.id);
+        }
+      });
+    }
+  }
+
+  _simulateInSceneNpcClick(npcId) {
+    if (this._renderedInSceneNpcs.includes(npcId)) {
+      this._handleNpcClick(npcId);
+      return true; // Click was processed
+    }
+    // console.log(`Simulated click on NPC ${npcId} ignored as it's not in _renderedInSceneNpcs.`);
+    return false; // Click was ignored
   }
 
   _handleNpcClick(npcId) {
@@ -99,12 +136,13 @@ class MockGameInterfaceViewForDialogues {
     this.requestUpdate();
   }
   
-  _getRenderedNpcIds() { // Conceptual check for what would be rendered
-    if (this.locationData && this.locationData.npcIds && this.locationData.npcIds.length > 0 && this.allNpcs && this.allNpcs.size > 0) {
-      return this.locationData.npcIds.filter(npcId => this.allNpcs.has(npcId));
-    }
-    return [];
-  }
+  // This method is being replaced by _updateRenderedInSceneNpcs and direct access to _renderedInSceneNpcs
+  // _getRenderedNpcIds() { 
+  //   if (this.locationData && this.locationData.npcIds && this.locationData.npcIds.length > 0 && this.allNpcs && this.allNpcs.size > 0) {
+  //     return this.locationData.npcIds.filter(npcId => this.allNpcs.has(npcId));
+  //   }
+  //   return [];
+  // }
 }
 
 
@@ -114,44 +152,48 @@ async function testNpcDialogueInteractions() {
   results.length = 0;
   const testSuiteName = "GameInterfaceView NPC & Dialogue Interaction Tests";
 
-  const npc1 = { id: "npc1", name: "Pirate Pete", icon: "person" };
-  const npc2 = { id: "npc2", name: "Mystic Mary", icon: "face_3" };
+  const npc1 = { id: "npc1", name: "Pirate Pete", icon: "person", position: { x: "10%", y: "20%" } };
+  const npc2 = { id: "npc2", name: "Mystic Mary", icon: "face_3", position: { x: "50%", y: "50%" } };
+  const npc3NoPos = { id: "npc3", name: "No Position Nick", icon: "person_off" };
   const dialogueNpc1 = {
     "start": { id: "start", npcText: "Arr, matey!", playerChoices: [{ text: "Hello", nextNodeId: "greet_reply" }] },
     "greet_reply": { id: "greet_reply", npcText: "Ahoy!", playerChoices: [{ text: "Bye", nextNodeId: "END" }] }
   };
 
   let view = new MockGameInterfaceViewForDialogues();
-  view.allNpcs.set("npc1", npc1);
-  view.allNpcs.set("npc2", npc2);
-  view.allDialogues["npc1"] = dialogueNpc1;
+  const initialNpcs = new Map([["npc1", npc1], ["npc2", npc2], ["npc3NoPos", npc3NoPos]]);
+  view.setAllNpcs(initialNpcs);
+  view.setAllDialogues({ "npc1": dialogueNpc1 });
 
-  view.locationData = { id: "loc1", name: "Test Location", npcIds: ["npc1"] };
-  let renderedNpcs = view._getRenderedNpcIds();
-  assertEqual(renderedNpcs.length, 1, "Test 1.1: Correct number of NPCs rendered");
-  assertTrue(renderedNpcs.includes("npc1"), "Test 1.2: NPC1 is rendered");
 
-  view.locationData = { id: "loc2", name: "Another Location", npcIds: ["npc2", "non_existent_npc"] };
-  renderedNpcs = view._getRenderedNpcIds();
-  assertEqual(renderedNpcs.length, 1, "Test 1.3: Only existing NPCs rendered");
-  assertTrue(renderedNpcs.includes("npc2"), "Test 1.4: NPC2 is rendered");
+  // --- Original Tests (adapted for setters) ---
+  view.setLocationData({ id: "loc1", name: "Test Location", npcIds: ["npc1"] });
+  // Test 1.1 & 1.2 are now covered by in-scene NPC tests.
+  // For simple presence in allNpcs, that's implicit.
+
+  // This test was about the _getRenderedNpcIds (text list), which is slightly different now.
+  // Let's keep its spirit for allNpcs general check.
+  view.setLocationData({ id: "loc2", name: "Another Location", npcIds: ["npc2", "non_existent_npc"] });
+  const presentNpcIdsInLocation = view.locationData.npcIds.filter(id => view.allNpcs.has(id));
+  assertEqual(presentNpcIdsInLocation.length, 1, "Test 1.3: Only existing NPCs considered from locationData.npcIds");
+  assertTrue(presentNpcIdsInLocation.includes("npc2"), "Test 1.4: NPC2 is considered from locationData.npcIds");
   
-  view.locationData = { id: "loc3", name: "Empty Location" };
-  renderedNpcs = view._getRenderedNpcIds();
-  assertEqual(renderedNpcs.length, 0, "Test 1.5: No NPCs rendered if npcIds missing/empty");
+  view.setLocationData({ id: "loc3", name: "Empty Location" });
+  assertEqual(view._renderedInSceneNpcs.length, 0, "Test 1.5: No in-scene NPCs if locationData.npcIds missing/empty");
 
-  view = new MockGameInterfaceViewForDialogues();
-  view.allNpcs.set("npc1", npc1);
-  view.allDialogues["npc1"] = dialogueNpc1;
-  view.locationData = { npcIds: ["npc1"] }; 
-  view._handleNpcClick("npc1");
-  assertEqual(view._activeDialogueNpcId, "npc1", "Test 2.1: Active NPC ID set");
-  assertEqual(view._currentDialogueNodeId, "start", "Test 2.2: Current node ID set to start");
-  assertNotNull(view._currentDialogueNode, "Test 2.3: Current dialogue node set");
+  // --- Test _handleNpcClick (dialogue initiation logic) ---
+  // This part is testing the original _handleNpcClick, which is fine.
+  // Simulate a click via the old way (e.g. text list) for npc1
+  view.setLocationData({ id: "loc_for_npc1_dialogue", name: "Pirate Cove", npcIds: ["npc1"] }); // Ensure npc1 is in this location
+  view._handleNpcClick("npc1"); // Simulate click from a text list or similar
+  assertEqual(view._activeDialogueNpcId, "npc1", "Test 2.1: Active NPC ID set via _handleNpcClick");
+  assertEqual(view._currentDialogueNodeId, "start", "Test 2.2: Current node ID set to start via _handleNpcClick");
+  assertNotNull(view._currentDialogueNode, "Test 2.3: Current dialogue node set via _handleNpcClick");
   if (view._currentDialogueNode) {
-    assertEqual(view._currentDialogueNode.npcText, "Arr, matey!", "Test 2.4: Correct NPC text for start node");
+    assertEqual(view._currentDialogueNode.npcText, "Arr, matey!", "Test 2.4: Correct NPC text for start node (via _handleNpcClick)");
   }
 
+  // --- Test dialogue progression (already good) ---
   assertTrue(view._currentDialogueNode && view._currentDialogueNode.playerChoices.length > 0, "Test 3.1: Start node has choices");
   if (view._currentDialogueNode && view._currentDialogueNode.playerChoices.length > 0) {
     view._handlePlayerChoice(view._currentDialogueNode.playerChoices[0]); 
@@ -170,12 +212,72 @@ async function testNpcDialogueInteractions() {
     }
   }
   
-  view = new MockGameInterfaceViewForDialogues();
-  view.allNpcs.set("npc2", npc2); 
-  view.locationData = { npcIds: ["npc2"] };
-  view._handleNpcClick("npc2"); // npc2 has no dialogue in this.allDialogues
+  // --- Test NPC with no dialogue (already good) ---
+  view = new MockGameInterfaceViewForDialogues(); // Fresh view
+  view.setAllNpcs(new Map([["npc2", npc2]])); // npc2 has no dialogue defined in view.allDialogues
+  view.setLocationData({ id: "loc_for_npc2_nodialogue", npcIds: ["npc2"] });
+  view._handleNpcClick("npc2"); 
   assertNull(view._currentDialogueNode, "Test 4.1: Dialogue node null for NPC with no dialogue tree");
   assertMatch(view._lastFoundMessage, "nothing to say", "Test 4.2: Message for NPC with no dialogue");
+
+  // --- New Tests for In-Scene NPC Rendering and Interaction ---
+  console.log("--- Starting New In-Scene NPC Tests ---");
+  view = new MockGameInterfaceViewForDialogues(); // Fresh view
+  view.setAllNpcs(initialNpcs); // npc1 (pos), npc2 (pos), npc3NoPos
+  view.setAllDialogues({ "npc1": dialogueNpc1, "npc2": { "start": {id: "start", npcText: "Mary speaks...", playerChoices:[]}} });
+
+  // Test 5: In-Scene NPC Presence
+  view.setLocationData({ id: "loc_scene1", name: "Scene Location 1", npcIds: ["npc1", "npc3NoPos"] });
+  assertEqual(view._renderedInSceneNpcs.length, 1, "Test 5.1: Correct number of in-scene NPCs rendered (1 with pos)");
+  assertTrue(view._renderedInSceneNpcs.includes("npc1"), "Test 5.2: NPC1 (with position) is in _renderedInSceneNpcs");
+  assertTrue(!view._renderedInSceneNpcs.includes("npc3NoPos"), "Test 5.3: NPC3 (no position) is NOT in _renderedInSceneNpcs");
+
+  view.setLocationData({ id: "loc_scene2", name: "Scene Location 2", npcIds: ["npc1", "npc2", "npc3NoPos", "non_existent_npc"] });
+  assertEqual(view._renderedInSceneNpcs.length, 2, "Test 5.4: Correct number of in-scene NPCs rendered (2 with pos)");
+  assertTrue(view._renderedInSceneNpcs.includes("npc1"), "Test 5.5: NPC1 (with position) is in _renderedInSceneNpcs for loc_scene2");
+  assertTrue(view._renderedInSceneNpcs.includes("npc2"), "Test 5.6: NPC2 (with position) is in _renderedInSceneNpcs for loc_scene2");
+  assertTrue(!view._renderedInSceneNpcs.includes("npc3NoPos"), "Test 5.7: NPC3 (no position) is still NOT in _renderedInSceneNpcs");
+  
+  view.setLocationData({ id: "loc_market", name: "Market Location", npcIds: ["npc1", "npc2"], isMarket: true });
+  assertEqual(view._renderedInSceneNpcs.length, 0, "Test 5.8: No in-scene NPCs rendered in a market location");
+
+  view.setLocationData({ id: "loc_scene_empty_npcs", name: "Scene Empty NPCs", npcIds: [] });
+  assertEqual(view._renderedInSceneNpcs.length, 0, "Test 5.9: No in-scene NPCs rendered if location.npcIds is empty");
+  
+  // Test 6: Clicking In-Scene NPC
+  view.setLocationData({ id: "loc_scene_for_click", name: "Click Test Scene", npcIds: ["npc1", "npc2"] }); // npc1 has dialogue
+  view._endDialogue(); // Ensure no prior dialogue state
+  
+  let clickHandled = view._simulateInSceneNpcClick("npc1");
+  assertTrue(clickHandled, "Test 6.1: _simulateInSceneNpcClick returns true for valid in-scene NPC");
+  assertEqual(view._activeDialogueNpcId, "npc1", "Test 6.2: Active NPC ID set after in-scene click");
+  assertEqual(view._currentDialogueNodeId, "start", "Test 6.3: Current node ID set to start after in-scene click");
+  assertNotNull(view._currentDialogueNode, "Test 6.4: Current dialogue node set after in-scene click");
+  if (view._currentDialogueNode) {
+    assertEqual(view._currentDialogueNode.npcText, "Arr, matey!", "Test 6.5: Correct NPC text from in-scene click");
+  }
+  view._endDialogue(); 
+
+  // Test 7: Clicking Non-Existent/Non-Rendered In-Scene NPC
+  view.setLocationData({ id: "loc_scene_for_bad_click", name: "Bad Click Test Scene", npcIds: ["npc2"] }); // npc2 is present, npc3NoPos is not rendered
+  view.setAllNpcs(new Map([["npc2", npc2], ["npc3NoPos", npc3NoPos]])); // Ensure npc3NoPos is in allNpcs but not rendered
+  view._endDialogue();
+
+  clickHandled = view._simulateInSceneNpcClick("npc3NoPos"); // npc3NoPos has no position data
+  assertTrue(!clickHandled, "Test 7.1: _simulateInSceneNpcClick returns false for NPC not rendered (no position)");
+  assertNull(view._activeDialogueNpcId, "Test 7.2: Dialogue not initiated for non-rendered NPC (no position)");
+
+  clickHandled = view._simulateInSceneNpcClick("non_existent_npc_id");
+  assertTrue(!clickHandled, "Test 7.3: _simulateInSceneNpcClick returns false for NPC not in allNpcs");
+  assertNull(view._activeDialogueNpcId, "Test 7.4: Dialogue not initiated for non-existent NPC ID");
+
+  view.setLocationData({ id: "loc_market_for_click_test", name: "Market Click Test", npcIds: ["npc1"], isMarket: true });
+  view.setAllNpcs(new Map([["npc1", npc1]])); // Ensure npc1 is in allNpcs
+  view._endDialogue();
+  clickHandled = view._simulateInSceneNpcClick("npc1"); // npc1 is in a market, so not "in-scene" rendered
+  assertTrue(!clickHandled, "Test 7.5: _simulateInSceneNpcClick returns false for NPC in market location");
+  assertNull(view._activeDialogueNpcId, "Test 7.6: Dialogue not initiated for NPC in market location via in-scene click");
+
 
   console.log(`--- ${testSuiteName} ---`);
   if (results.length > 0) { results.forEach(r => console.log(r)); }

--- a/www/data/dialogues.json
+++ b/www/data/dialogues.json
@@ -18,6 +18,11 @@
           "text": "I'm looking for adventure... and treasure!",
           "nextNodeId": "jack_adventure",
           "action": null
+        },
+        {
+          "text": "Tell me a funny story, pirate.",
+          "nextNodeId": "jack_funny_story_start",
+          "action": null
         }
       ]
     },
@@ -65,6 +70,71 @@
       "playerChoices": [
         {
           "text": "Farewell, Jack.",
+          "nextNodeId": "END",
+          "action": null
+        }
+      ]
+    },
+    "jack_funny_story_start": {
+      "id": "jack_funny_story_start",
+      "npcText": "A funny story, eh? Alright, settle down. Reminds me of this one time, I had a parrot, see? Smartest bird I ever knew. Went into a tavern, and the blasted thing hops on the bar and squawks, 'A keg o' rum for me captain, and a cracker for me!' So the barkeep says...",
+      "playerChoices": [
+        {
+          "text": "And what did the barkeep say?",
+          "nextNodeId": "jack_parrot_punchline",
+          "action": null
+        },
+        {
+          "text": "That's not very funny yet.",
+          "nextNodeId": "jack_skeptical",
+          "action": null
+        }
+      ]
+    },
+    "jack_skeptical": {
+      "id": "jack_skeptical",
+      "npcText": "Hold yer seahorses, I'm gettin' to the good part! Patience, lad/lass, patience. A good story is like a fine grog, needs time to be savored.",
+      "playerChoices": [
+        {
+          "text": "Alright, alright, go on.",
+          "nextNodeId": "jack_parrot_punchline",
+          "action": null
+        }
+      ]
+    },
+    "jack_parrot_punchline": {
+      "id": "jack_parrot_punchline",
+      "npcText": "The barkeep, he looks at the parrot, then at me, then back at the parrot and says, 'That'll be ten gold pieces for the rum. The cracker's on the house for the bird, but he better not try to pay with doubloons he's... *found*.' Har har! Turns out the parrot had been swipin' coins from the collection plate at the church!",
+      "playerChoices": [
+        {
+          "text": "Hah! That's a good one!",
+          "nextNodeId": "jack_laugh_end",
+          "action": null
+        },
+        {
+          "text": "Got any more like that?",
+          "nextNodeId": "jack_parrot_another",
+          "action": null
+        }
+      ]
+    },
+    "jack_laugh_end": {
+      "id": "jack_laugh_end",
+      "npcText": "Aye, gets 'em every time. Now, if ye'll excuse me, I've got a thirst that needs quench'n'.",
+      "playerChoices": [
+        {
+          "text": "See you around, Jack.",
+          "nextNodeId": "END",
+          "action": null
+        }
+      ]
+    },
+    "jack_parrot_another": {
+      "id": "jack_parrot_another",
+      "npcText": "Afraid that's the only one fit for polite company, matey. The rest are a bit too... *piratey*, if ye catch my drift. Maybe another time, eh?",
+      "playerChoices": [
+        {
+          "text": "Understood. Thanks for the story!",
           "nextNodeId": "END",
           "action": null
         }

--- a/www/data/npcs.json
+++ b/www/data/npcs.json
@@ -6,7 +6,8 @@
     "icon": "person",
     "defaultLocationId": "tortuga_town",
     "portraitImage": "../www/assets/images/portraits/one_eyed_jack_portrait.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "20%", "y": "50%" }
   },
   {
     "id": "npc_mysterious_woman",
@@ -15,7 +16,8 @@
     "icon": "face_3",
     "defaultLocationId": "hidden_lagoon",
     "portraitImage": "../www/assets/images/portraits/mysterious_woman_portrait.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "75%", "y": "30%" }
   },
   {
     "id": "npc_shady_merchant",
@@ -24,7 +26,8 @@
     "icon": "store",
     "defaultLocationId": "port_royal_market",
     "portraitImage": "../www/assets/images/portraits/shady_merchant_portrait.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "50%", "y": "50%" }
   },
   {
     "id": "npc_kraken_abyss",
@@ -33,7 +36,8 @@
     "icon": "person_pin",
     "defaultLocationId": "kraken_abyss",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_1.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "60%", "y": "70%" }
   },
   {
     "id": "npc_cursed_galleon_graveyard",
@@ -42,7 +46,8 @@
     "icon": "person_pin",
     "defaultLocationId": "cursed_galleon_graveyard",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_2.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "30%", "y": "40%" }
   },
   {
     "id": "npc_mermaid_rock",
@@ -51,7 +56,8 @@
     "icon": "person_pin",
     "defaultLocationId": "mermaid_rock",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_3.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "80%", "y": "80%" }
   },
   {
     "id": "npc_blackbeards_hidden_cache",
@@ -60,7 +66,8 @@
     "icon": "person_pin",
     "defaultLocationId": "blackbeards_hidden_cache",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_4.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "45%", "y": "55%" }
   },
   {
     "id": "npc_stormy_cape_of_no_return",
@@ -69,7 +76,8 @@
     "icon": "person_pin",
     "defaultLocationId": "stormy_cape_of_no_return",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_5.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "25%", "y": "65%" }
   },
   {
     "id": "npc_davy_jones_locker_entrance",
@@ -78,7 +86,8 @@
     "icon": "person_pin",
     "defaultLocationId": "davy_jones_locker_entrance",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_6.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "50%", "y": "20%" }
   },
   {
     "id": "npc_cannibal_island",
@@ -87,7 +96,8 @@
     "icon": "person_pin",
     "defaultLocationId": "cannibal_island",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_7.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "70%", "y": "75%" }
   },
   {
     "id": "npc_smugglers_secret_strait",
@@ -96,7 +106,8 @@
     "icon": "person_pin",
     "defaultLocationId": "smugglers_secret_strait",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_8.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "15%", "y": "85%" }
   },
   {
     "id": "npc_treasure_fleet_wreckage_site",
@@ -105,7 +116,8 @@
     "icon": "person_pin",
     "defaultLocationId": "treasure_fleet_wreckage_site",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_9.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "65%", "y": "35%" }
   },
   {
     "id": "npc_fort_caroline_ruins",
@@ -114,7 +126,8 @@
     "icon": "person_pin",
     "defaultLocationId": "fort_caroline_ruins",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_10.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "40%", "y": "25%" }
   },
   {
     "id": "npc_ship_trap_island",
@@ -123,7 +136,8 @@
     "icon": "person_pin",
     "defaultLocationId": "ship_trap_island",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_11.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "55%", "y": "45%" }
   },
   {
     "id": "npc_marooners_rock",
@@ -132,7 +146,8 @@
     "icon": "person_pin",
     "defaultLocationId": "marooners_rock",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_12.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "20%", "y": "70%" }
   },
   {
     "id": "npc_the_leviathans_ribcage",
@@ -141,7 +156,8 @@
     "icon": "person_pin",
     "defaultLocationId": "the_leviathans_ribcage",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_13.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "80%", "y": "15%" }
   },
   {
     "id": "npc_coral_reef_labyrinth",
@@ -150,7 +166,8 @@
     "icon": "person_pin",
     "defaultLocationId": "coral_reef_labyrinth",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_14.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "35%", "y": "80%" }
   },
   {
     "id": "npc_skeleton_key_islet",
@@ -159,7 +176,8 @@
     "icon": "person_pin",
     "defaultLocationId": "skeleton_key_islet",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_15.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "60%", "y": "10%" }
   },
   {
     "id": "npc_the_barnacle_bank",
@@ -168,7 +186,8 @@
     "icon": "person_pin",
     "defaultLocationId": "the_barnacle_bank",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_16.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "40%", "y": "60%" }
   },
   {
     "id": "npc_ghost_ship_anchorage",
@@ -177,7 +196,8 @@
     "icon": "person_pin",
     "defaultLocationId": "ghost_ship_anchorage",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_17.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "70%", "y": "20%" }
   },
   {
     "id": "npc_sea_serpents_pass",
@@ -186,7 +206,8 @@
     "icon": "person_pin",
     "defaultLocationId": "sea_serpents_pass",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_18.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "25%", "y": "30%" }
   },
   {
     "id": "npc_dead_mans_chest_island",
@@ -195,7 +216,8 @@
     "icon": "person_pin",
     "defaultLocationId": "dead_mans_chest_island",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_19.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "55%", "y": "75%" }
   },
   {
     "id": "npc_rum_runners_rendezvous",
@@ -204,7 +226,8 @@
     "icon": "person_pin",
     "defaultLocationId": "rum_runners_rendezvous",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_20.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "10%", "y": "50%" }
   },
   {
     "id": "npc_spyglass_hill",
@@ -213,7 +236,8 @@
     "icon": "person_pin",
     "defaultLocationId": "spyglass_hill",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_21.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "85%", "y": "40%" }
   },
   {
     "id": "npc_mutineers_gallows",
@@ -222,7 +246,8 @@
     "icon": "person_pin",
     "defaultLocationId": "mutineers_gallows",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_22.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "30%", "y": "90%" }
   },
   {
     "id": "npc_buried_doubloon_beach",
@@ -231,7 +256,8 @@
     "icon": "person_pin",
     "defaultLocationId": "buried_doubloon_beach",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_23.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "65%", "y": "5%" }
   },
   {
     "id": "npc_captains_quarrel_cove",
@@ -240,7 +266,8 @@
     "icon": "person_pin",
     "defaultLocationId": "captains_quarrel_cove",
     "portraitImage": "../www/assets/images/portraits/placeholder_npc_24.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "50%", "y": "65%" }
   },
   {
     "id": "npc_wandering_bard",
@@ -248,7 +275,8 @@
     "description": "A cheerful bard strumming lively shanties, always ready with an encouraging word or a tale of heroism.",
     "icon": "music_note",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_1.png",
-    "alignment": "good"
+    "alignment": "good",
+    "position": { "x": "50%", "y": "50%" }
   },
   {
     "id": "npc_shipwrecked_sailor",
@@ -256,7 +284,8 @@
     "description": "A grateful sailor rescued from a deserted island, eager to repay your kindness.",
     "icon": "person_pin",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_2.png",
-    "alignment": "good"
+    "alignment": "good",
+    "position": { "x": "40%", "y": "60%" }
   },
   {
     "id": "npc_helpful_islander",
@@ -264,7 +293,8 @@
     "description": "A native islander offering guidance or a rare fruit, asking for nothing in return.",
     "icon": "emoji_people",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_3.png",
-    "alignment": "good"
+    "alignment": "good",
+    "position": { "x": "60%", "y": "40%" }
   },
   {
     "id": "npc_retired_naval_officer",
@@ -272,7 +302,8 @@
     "description": "An old, honorable naval officer who shares wisdom about the seas and despises pirates but respects courage.",
     "icon": "military_tech",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_4.png",
-    "alignment": "good"
+    "alignment": "good",
+    "position": { "x": "55%", "y": "45%" }
   },
   {
     "id": "npc_traveling_merchant",
@@ -280,7 +311,8 @@
     "description": "A pragmatic merchant sailing a small sloop, offering common goods at fair prices.",
     "icon": "store",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_5.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "45%", "y": "55%" }
   },
   {
     "id": "npc_hermit_crab_collector",
@@ -288,7 +320,8 @@
     "description": "An eccentric individual obsessed with collecting rare hermit crab shells, willing to trade information for unique finds.",
     "icon": "bug_report",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_6.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "30%", "y": "70%" }
   },
   {
     "id": "npc_castaway_cartographer",
@@ -296,7 +329,8 @@
     "description": "A cartographer who claims to have lost his valuable maps, seeking passage to any port.",
     "icon": "map",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_7.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "70%", "y": "30%" }
   },
   {
     "id": "npc_superstitious_fisherman",
@@ -304,7 +338,8 @@
     "description": "A fisherman guided by omens and rituals, wary of strangers but knowledgeable about local waters.",
     "icon": "phishing",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_8.png",
-    "alignment": "neutral"
+    "alignment": "neutral",
+    "position": { "x": "20%", "y": "80%" }
   },
   {
     "id": "npc_cutthroat_buccaneer",
@@ -312,7 +347,8 @@
     "description": "A menacing pirate spoiling for a fight, demanding tribute or your life.",
     "icon": "sports_kabaddi",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_9.png",
-    "alignment": "evil"
+    "alignment": "evil",
+    "position": { "x": "80%", "y": "20%" }
   },
   {
     "id": "npc_deceptive_siren",
@@ -320,7 +356,8 @@
     "description": "A beautiful creature whose enchanting song lures sailors to their doom, or at least to part with their gold.",
     "icon": "voice_over_record",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_10.png",
-    "alignment": "evil"
+    "alignment": "evil",
+    "position": { "x": "75%", "y": "75%" }
   },
   {
     "id": "npc_cursed_treasure_guardian",
@@ -328,7 +365,8 @@
     "description": "A spectral guardian bound to a cursed treasure, attacking anyone who comes near.",
     "icon": "ghost",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_11.png",
-    "alignment": "evil"
+    "alignment": "evil",
+    "position": { "x": "25%", "y": "25%" }
   },
   {
     "id": "npc_ruthless_slave_trader",
@@ -336,6 +374,7 @@
     "description": "A vile individual looking to capture unsuspecting sailors for a quick profit.",
     "icon": "money_off",
     "portraitImage": "../www/assets/images/portraits/placeholder_random_npc_12.png",
-    "alignment": "evil"
+    "alignment": "evil",
+    "position": { "x": "60%", "y": "60%" }
   }
 ]

--- a/www/src/game-interface-view.js
+++ b/www/src/game-interface-view.js
@@ -58,6 +58,28 @@ class GameInterfaceView extends LitElement {
       color: #FDF5E6; /* cream */
       text-shadow: 1px 1px 2px #3C2F2F; /* dark brown shadow */
     }
+    .in-scene-npc {
+      position: absolute;
+      width: 55px; 
+      height: 55px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.2s ease-out, box-shadow 0.2s ease-out;
+      border: 2px dashed #FFD700; /* Dashed gold border */
+      border-radius: 50%; /* Circular shape */
+      background-color: rgba(0, 0, 0, 0.15); /* Subtle dark background */
+    }
+    .in-scene-npc:hover {
+      transform: scale(1.15);
+      box-shadow: 0 0 12px #FFD700; /* Gold glow */
+    }
+    .in-scene-npc md-icon {
+      font-size: 38px; 
+      color: #FDF5E6; /* Cream icon color */
+      text-shadow: 1px 1px 2px #3C2F2F; /* Dark brown shadow */
+    }
     .actions-panel {
       position: absolute;
       bottom: 20px;
@@ -450,9 +472,11 @@ class GameInterfaceView extends LitElement {
 
     let contentHtml;
     let npcListHtml = html``;
+    let inSceneNpcsHtml = html``; // For NPCs rendered directly in the scene
 
     // Render NPCs if present
     if (this.locationData && this.locationData.npcIds && this.locationData.npcIds.length > 0 && this.allNpcs.size > 0) {
+      // This is the existing NPC list, potentially for a side panel or market view
       npcListHtml = html`
         <div class="npc-list">
           <h4>${msg('People Here', {id: 'npc-list-header'})}:</h4>
@@ -467,6 +491,26 @@ class GameInterfaceView extends LitElement {
           })}
         </div>
       `;
+
+      // New logic for rendering NPCs directly in the scene
+      if (!this.locationData.isMarket) { // Only render in-scene if not a market view
+        inSceneNpcsHtml = html`
+          ${this.locationData.npcIds.map(npcId => {
+            const npc = this.allNpcs.get(npcId);
+            if (npc && npc.position && npc.position.x && npc.position.y) {
+              return html`
+                <div class="in-scene-npc"
+                     style="left: ${npc.position.x}; top: ${npc.position.y};"
+                     title="${npc.name}"
+                     @click=${() => this._handleNpcClick(npc.id)}>
+                  <md-icon>${npc.icon || 'person'}</md-icon>
+                </div>
+              `;
+            }
+            return '';
+          })}
+        `;
+      }
     }
 
     if (this.locationData.isMarket) {
@@ -502,7 +546,8 @@ class GameInterfaceView extends LitElement {
       `;
     } else { // Not a market, render hidden objects and NPCs
       contentHtml = html`
-        ${npcListHtml}
+        ${npcListHtml} {/* This is the existing list, could be removed or kept depending on final UI */}
+        
         ${this.locationData.hiddenObjects?.map(objInLocation => {
           let itemDetails = null;
           let displayId = objInLocation.id; 
@@ -552,6 +597,7 @@ class GameInterfaceView extends LitElement {
           }
           return ''; 
         })}
+        ${inSceneNpcsHtml} {/* Add new in-scene NPCs here, after hidden objects */}
       `;
     }
 


### PR DESCRIPTION
This commit introduces the ability to render NPCs as clickable entities directly within the game view of their respective locations.

Key changes:
- NPCs in `npcs.json` now have a `position` property to define their coordinates in their default location.
- `game-interface-view.js` has been updated to:
    - Render NPCs with position data as interactive icons within the game scene (for non-market locations).
    - Apply new CSS styles (`.in-scene-npc`) for these visual NPC elements, including hover effects.
    - Clicking these in-scene NPCs initiates dialogue.
- The existing text-based list of NPCs at a location is preserved.
- Added a humorous dialogue path for 'npc_one_eyed_jack' in `dialogues.json`.
- Verified that `pois.json` correctly assigns NPCs to locations.
- Updated and extended tests in `test/game-interface-view.npcs-dialogues.test.js` to cover the new in-scene NPC rendering logic and click interactions.