### PR TITLE
Refactor: Standardize view sizing and add view transitions

### DIFF
--- a/www/src/game-interface-view.js
+++ b/www/src/game-interface-view.js
@@ -8,22 +8,24 @@ import './npc-dialog-overlay.js'; // Import the new component
 class GameInterfaceView extends LitElement {
   static styles = css`
     :host {
-      display: block;
-      padding: 0; /* Remove padding if viewport takes full space */
+      display: flex; /* Changed from block */
+      flex-direction: column; /* To allow viewport to grow */
+      flex-grow: 1; /* Allow this view to take available space in its parent */
+      padding: 0;
       width: 100%;
-      height: calc(100vh - 150px); /* Adjust based on header/footer/nav height */
+      /* height: calc(100vh - 150px); */ /* REMOVE this line */
       box-sizing: border-box;
       position: relative; /* For absolute positioning of UI elements */
     }
     .viewport {
+      flex-grow: 1; /* Allow viewport to take available space within the host */
       width: 100%;
-      height: 100%;
+      /* height: 100%; */ /* No longer needed if flex-grow is used */
       background-size: cover;
       background-position: center;
       position: relative; /* For positioning hidden objects */
       overflow: hidden;
       border: 3px solid #3C2F2F; /* dark brown */
-      /* Vignette effect from map-view, if desired here too */
       box-shadow: inset 0 0 30px rgba(0,0,0,0.5); /* Inner shadow for depth - Keep */
     }
     .location-title {

--- a/www/src/map-view.js
+++ b/www/src/map-view.js
@@ -5,8 +5,10 @@ import '@material/web/icon/icon.js';
 class MapView extends LitElement {
   static styles = css`
     :host {
-      display: block;
-      text-align: center; /* Center the map container if it's narrower than host */
+      display: flex; /* Added */
+      flex-direction: column; /* Added */
+      flex-grow: 1; /* Added */
+      text-align: center;
     }
     h2 {
       /* Inherits global styles */
@@ -40,38 +42,45 @@ class MapView extends LitElement {
       font-family: 'MainTextFont', serif; /* Placeholder */
     }
     .map-container {
-      width: 90%; /* Or a fixed width like 500px */
-      max-width: 600px;
-      height: 400px;
-      border: 5px solid #3C2F2F; /* dark brown, thicker */
-      /* Conceptual: border-image-source: url('assets/images/theme/map_frame.png'); */
-      /* border-image-slice: 20; */
-      /* border-image-width: 20px; */
-      /* border-image-repeat: round; */
-      overflow: auto; /* Important for scrolling */
-      margin: 0 auto; /* Center the container */
-      overscroll-behavior: none; /* Prevent bounce/rubber-band scrolling */
-      background-color: #5C8D9C; /* muted sea blue for areas around map image */
-      position: relative; /* For potential future absolute positioning of map elements */
+      /* width: 90%; */ /* REMOVE */
+      /* max-width: 600px; */ /* REMOVE */
+      /* height: 400px; */ /* REMOVE */
+      /* margin: 0 auto; */ /* REMOVE */
+      width: 100%; /* ADDED */
+      flex-grow: 1; /* ADDED, to fill :host */
+      display: flex; /* ADDED, to help center map-content if it's smaller */
+      justify-content: center; /* ADDED, to center map-content horizontally */
+      align-items: center; /* ADDED, to center map-content vertically */
+      border: 5px solid #3C2F2F;
+      overflow: auto;
+      /* overscroll-behavior: none; */ /* This is fine */
+      background-color: #5C8D9C;
+      position: relative;
       cursor: grab;
-
-      /* Hide scrollbars */
+      box-shadow: inset 0 0 25px 15px rgba(0,0,0,0.35);
       scrollbar-width: none; /* For Firefox */
-
-      /* Vignette effect */
-      box-shadow: inset 0 0 25px 15px rgba(0,0,0,0.35); /* Keep */
     }
-
     .map-container::-webkit-scrollbar {
       display: none; /* Hide scrollbar */
     }
     .map-content {
-      width: 1280px; /* Keep original map size */
-      height: 896px; /* Keep original map size */
-      /* Conceptual: background-image: url('assets/images/theme/pirate_map_background.jpg'); */
-      background-image: url(../www/assets/images/mapv1.jpg); /* Current image */
+      /* width: 1280px; */ /* REMOVE */
+      /* height: 896px; */ /* REMOVE */
+
+      /* New approach to maintain aspect ratio of the map image (1280x896) */
+      /* while fitting within the container. The map image itself will be the background. */
+      width: 100%; /* Fill the width of map-container */
+      /* Calculate aspect ratio: (896 / 1280) * 100% = 70% */
+      /* This means height is 70% of the width. */
+      /* We achieve this by setting height to 0 and using padding-bottom. */
+      height: 0;
+      padding-bottom: 70%; /* This sets the height relative to the width */
+
+      background-image: url(../www/assets/images/mapv1.jpg);
       background-repeat: no-repeat;
-      position: relative;
+      background-size: 100% 100%; /* Stretch background image to fill the div */
+      position: relative; /* Keep for POI markers */
+      /* transform: scale() is applied via inline style by Lit, keep that */
     }
 
     @keyframes pulseAnimation {


### PR DESCRIPTION
This commit addresses issue #<issue_number_if_available> to improve the UI flow between the map and game views.

Key changes:

1.  **Standardized View Sizing:**
    - Modified `app-shell.js` to use a flexbox layout, ensuring the main view container (`div.view-container`) expands to fill available vertical space between the header/nav and footer.
    - Updated `game-interface-view.js` to remove its fixed height calculation and instead use flexbox (`flex-grow: 1`) to fill the height provided by `app-shell`'s view container.
    - Updated `map-view.js` similarly to fill the available height. The map content (`div.map-content`) now maintains its aspect ratio (1280x896) within the flexible container using `padding-bottom: 70%` and stretches its background image (`background-size: 100% 100%`). POI markers are now positioned using percentages to scale correctly with the responsive map.

2.  **Fade Transitions:**
    - Implemented fade-in transitions in `app-shell.js`. When you navigate between views, the new view content now fades in. This is achieved by briefly clearing the view container and then re-rendering the new view with a CSS fade-in animation. This provides a smoother visual experience than an abrupt view switch.

These changes make the map and game views effectively the same size within the application window and improve the perceived seamlessness of transitioning between them.