### PR TITLE
I've enhanced Esmeralda's riddle and developed a multi-stage artifact…

### DIFF
--- a/www/data/dialogues.json
+++ b/www/data/dialogues.json
@@ -192,6 +192,11 @@
           "text": "Heard any whispers about 'The Crimson Marauders'?",
           "nextNodeId": "moreau_crimson_marauders_intro",
           "action": null
+        },
+        {
+          "text": "Heard you might have a sensitive problem needing discretion?",
+          "nextNodeId": "moreau_spy_investigation_intro",
+          "condition": {"questStatus": {"questId": "MOREAU_TORTUGA_SPY_QUEST", "status": "available"}}
         }
       ]
     },
@@ -325,7 +330,10 @@
         {
           "text": "Let me see the coded message.",
           "nextNodeId": null,
-          "effects": [{ "type": "TRIGGER_PUZZLE", "puzzleId": "CRIMSON_MAP_CIPHER" }]
+          "effects": [
+            {"type": "TRIGGER_PUZZLE", "puzzleId": "CRIMSON_MAP_CIPHER"},
+            {"type": "START_QUEST", "questId": "MOREAU_CRIMSON_MAP_QUEST"}
+          ]
         },
         {
           "text": "On second thought, perhaps not now.",
@@ -375,6 +383,45 @@
           "action": null
         }
       ]
+    },
+    "moreau_spy_investigation_intro": {
+      "id": "moreau_spy_investigation_intro",
+      "npcText": "Indeed. I have a rat problem. A spy in Tortuga feeding information to the Royal Navy. This compromises my operations, and I need it dealt with. Think you can handle such a delicate task?",
+      "playerChoices": [
+        {
+          "text": "I'm good at uncovering secrets. Tell me more.",
+          "nextNodeId": "moreau_spy_investigation_start"
+        },
+        {
+          "text": "Sounds too risky for me, Captain.",
+          "nextNodeId": "END"
+        }
+      ]
+    },
+    "moreau_spy_investigation_start": {
+      "id": "moreau_spy_investigation_start",
+      "npcText": "Alright. I have a few suspects. This requires sharp deduction, not just brute force. Listen carefully...",
+      "effects": [
+        {"type": "TRIGGER_PUZZLE", "puzzleId": "TORTUGA_SPY_DEDUCTION"},
+        {"type": "START_QUEST", "questId": "MOREAU_TORTUGA_SPY_QUEST"}
+      ],
+      "playerChoices": [
+        { "text": "I'm ready. Present the suspects and clues.", "nextNodeId": "END" }
+      ]
+    },
+    "MOREAU_SPY_IDENTIFIED_SUCCESS": {
+      "id": "MOREAU_SPY_IDENTIFIED_SUCCESS",
+      "npcText": "Excellent work. You've sniffed out the rat. My operations are secure once more, thanks to you. You've earned this.",
+      "playerChoices": [
+        { "text": "Glad I could be of service, Captain.", "nextNodeId": "END" }
+      ]
+    },
+    "MOREAU_SPY_IDENTIFIED_FAILURE": {
+      "id": "MOREAU_SPY_IDENTIFIED_FAILURE",
+      "npcText": "Wrong suspect! Or perhaps you took too long... The real spy has slipped through our fingers, and my operations are at greater risk. Disappointing.",
+      "playerChoices": [
+        { "text": "My apologies, Captain.", "nextNodeId": "END" }
+      ]
     }
   },
   "npc_silas_blackwood": {
@@ -406,7 +453,84 @@
             "questStatus": {"questId": "SILAS_CURSED_ARTIFACT_PART", "status": "in_progress"},
             "hasItem": "item_shadow_gem"
           }
+        },
+        {
+          "text": "You mentioned 'unique items'. Are any truly legendary?",
+          "nextNodeId": "silas_intro_sunken_star_quest_check",
+          "condition": {"questStatus": {"questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "status": "available"}}
         }
+      ]
+    },
+    "silas_intro_sunken_star_quest_check": {
+      "id": "silas_intro_sunken_star_quest_check",
+      "npcText": "Legendary, you say? I might just have something that piques your interest. It involves a bit of... legwork, but the rewards could be substantial. Are you intrigued?",
+      "playerChoices": [
+        { "text": "My interest is piqued. Tell me more, Silas.", "nextNodeId": "silas_intro_sunken_star_quest" },
+        { "text": "Perhaps another time. What else do you have?", "nextNodeId": "silas_unique_items" }
+      ]
+    },
+    "silas_intro_sunken_star_quest": {
+      "id": "silas_intro_sunken_star_quest",
+      "npcText": "It's the Amulet of the Sunken Star, an artifact of considerable power. Alas, it's broken. I need someone... resourceful... to find its three pieces. The first, a Curved Obsidian Shard, is said to lie hidden amongst the fiery rocks of Volcano Island. The second, a Sun-Bleached Coral Fragment, was last seen near the Hidden Lagoon; look for where the water meets ancient stone. Find these two, bring them to me, and I shall provide the third piece, a Humming Pearl only I can procure.",
+      "effects": [{"type": "START_QUEST", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST"}],
+      "playerChoices": [
+        { "text": "I'll find these pieces for you, Silas.", "nextNodeId": "silas_check_amulet_pieces" }, // Changed to lead to check node
+        { "text": "That sounds like a lot of trouble.", "nextNodeId": "END" }
+      ]
+    },
+    "silas_check_amulet_pieces": {
+      "id": "silas_check_amulet_pieces",
+      "npcText": "Ah, back so soon? Any luck with the amulet pieces?",
+      "playerChoices": [
+        {
+          "text": "I found the Obsidian Shard from Volcano Island.",
+          "nextNodeId": "silas_receive_obsidian_shard",
+          "condition": { "hasItem": "artifact_piece_1_obsidian", "questInProgress": "SILAS_SUNKEN_STAR_AMULET_QUEST" }
+        },
+        {
+          "text": "I found the Coral Fragment from the Hidden Lagoon.",
+          "nextNodeId": "silas_receive_coral_fragment",
+          "condition": { "hasItem": "artifact_piece_2_coral", "questInProgress": "SILAS_SUNKEN_STAR_AMULET_QUEST" }
+        },
+        {
+          "text": "I have both the Shard and the Fragment!",
+          "nextNodeId": "silas_has_both_pieces_provide_pearl",
+          "condition": { "hasItems": ["artifact_piece_1_obsidian", "artifact_piece_2_coral"], "questInProgress": "SILAS_SUNKEN_STAR_AMULET_QUEST" }
+        },
+        { "text": "Still working on it, Silas.", "nextNodeId": "END" },
+        { "text": "I want to talk about something else.", "nextNodeId": "silas_start"} // Allow to go back to main options
+      ]
+    },
+    "silas_receive_obsidian_shard": {
+      "id": "silas_receive_obsidian_shard",
+      "npcText": "Excellent! This obsidian is just as I envisioned. One step closer. Now, what about the coral fragment?",
+      "effects": [{"type": "UPDATE_QUEST_OBJECTIVE", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "objectiveId": "find_obsidian_shard", "isCompleted": true}],
+      "playerChoices": [
+        {"text": "I'm still looking for the Coral Fragment.", "nextNodeId": "silas_check_amulet_pieces"},
+        {"text": "I actually have the Coral Fragment too.", "nextNodeId": "silas_has_both_pieces_provide_pearl", "condition": {"hasItem": "artifact_piece_2_coral"}}
+      ]
+    },
+    "silas_receive_coral_fragment": {
+      "id": "silas_receive_coral_fragment",
+      "npcText": "Splendid! This coral has the exact markings I was told of. Very good. And the obsidian shard?",
+      "effects": [{"type": "UPDATE_QUEST_OBJECTIVE", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "objectiveId": "find_coral_fragment", "isCompleted": true}],
+      "playerChoices": [
+        {"text": "I'm still looking for the Obsidian Shard.", "nextNodeId": "silas_check_amulet_pieces"},
+        {"text": "I actually have the Obsidian Shard too.", "nextNodeId": "silas_has_both_pieces_provide_pearl", "condition": {"hasItem": "artifact_piece_1_obsidian"}}
+      ]
+    },
+    "silas_has_both_pieces_provide_pearl": {
+      "id": "silas_has_both_pieces_provide_pearl",
+      "npcText": "Magnificent! You've found both the Obsidian Shard and the Coral Fragment! You've proven your worth. As promised, here is the Humming Pearl. With all three pieces, you should now be able to attempt the reassembly. Be careful, it's a delicate process.",
+      "effects": [
+        {"type": "UPDATE_QUEST_OBJECTIVE", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "objectiveId": "find_obsidian_shard", "isCompleted": true},
+        {"type": "UPDATE_QUEST_OBJECTIVE", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "objectiveId": "find_coral_fragment", "isCompleted": true},
+        {"type": "ADD_ITEM", "itemId": "artifact_piece_3_pearl"},
+        {"type": "UPDATE_QUEST_OBJECTIVE", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "objectiveId": "obtain_humming_pearl", "isCompleted": true}
+      ],
+      "playerChoices": [
+        { "text": "Thank you, Silas. I'll try to assemble it now.", "nextNodeId": "silas_trigger_assembly_prompt" },
+        { "text": "I need a moment before I try.", "nextNodeId": "END"}
       ]
     },
     "silas_check_artifact_quest_availability": {
@@ -509,7 +633,7 @@
       ]
     },
     "silas_artifact_assembly_prompt": {
-      "id": "silas_artifact_assembly_prompt",
+      "id": "silas_artifact_assembly_prompt", // This node might be kept for other scenarios or removed if only quest-driven
       "npcText": "Eager, are we? Very well. I recently acquired... or rather, *liberated*... these fragments. They are said to form the Amulet of the Sunken Star. See if you can piece it together. Its value would increase significantly if complete.",
       "playerChoices": [
         {
@@ -522,18 +646,62 @@
         }
       ]
     },
+    "silas_artifact_assembly_prompt_conditional": {
+      "id": "silas_trigger_assembly_prompt",
+      "npcText": "You have all three pieces of the Sunken Star Amulet. The moment of truth. Are you ready to attempt the reassembly? Remember, it requires a keen eye and a steady hand.",
+      "condition": { // This condition could also be on the player choice in silas_check_amulet_pieces leading here
+        "questInProgress": "SILAS_SUNKEN_STAR_AMULET_QUEST",
+        "questObjectiveCompleted": "obtain_humming_pearl",
+        "hasItems": ["artifact_piece_1_obsidian", "artifact_piece_2_coral", "artifact_piece_3_pearl"]
+      },
+      "playerChoices": [
+        {
+          "text": "Yes, I'm ready. Let's do this.",
+          "effects": [{"type": "TRIGGER_PUZZLE", "puzzleId": "ANCIENT_ARTIFACT_ASSEMBLY"}]
+        },
+        { "text": "I need more time to prepare.", "nextNodeId": "END" }
+      ]
+    },
     "silas_artifact_assembly_success": {
       "id": "silas_artifact_assembly_success",
-      "npcText": "Remarkable! You have a keen eye and steady hands. The Amulet of the Sunken Star, whole once more! This changes things... for both of us.",
+      "npcText": "Remarkable! You've done it! The Amulet of the Sunken Star, whole once more! Its power... palpable. You've exceeded my expectations. As per our arrangement, your reward.",
       "playerChoices": [
-        { "text": "What do you propose, Silas?", "nextNodeId": "END" }
+        { "text": "It was a challenge, but worth it.", "nextNodeId": "silas_discuss_amulet_future" }
       ]
+    },
+    "silas_discuss_amulet_future": {
+      "id": "silas_discuss_amulet_future",
+      "npcText": "Indeed. Now, about the amulet itself. It's quite valuable. I could take it off your hands for a handsome sum of additional gold... say, 500 pieces? Or perhaps you'd prefer to keep it? It might have... unforeseen benefits for its owner.",
+      "playerChoices": [
+        {
+          "text": "Sell it to Silas for 500 Gold.",
+          "effects": [
+            {"type": "REMOVE_ITEM", "itemId": "amulet_sunken_star_complete"},
+            {"type": "ADD_RESOURCE", "resource": "gold", "amount": 500}
+          ],
+          "nextNodeId": "silas_amulet_sold"
+        },
+        {
+          "text": "I think I'll keep the Amulet.",
+          "nextNodeId": "silas_amulet_kept"
+        }
+      ]
+    },
+    "silas_amulet_sold": {
+      "id": "silas_amulet_sold",
+      "npcText": "A wise choice. Pleasure doing business with you, as always. The gold is yours. I have... plans for this.",
+      "playerChoices": [ {"text": "Farewell, Silas.", "nextNodeId": "END"} ]
+    },
+    "silas_amulet_kept": {
+      "id": "silas_amulet_kept",
+      "npcText": "Holding onto it, eh? Bold. May it serve you well... or lead you to interesting places. Do let me know if it reveals any peculiar properties.",
+      "playerChoices": [ {"text": "I will. Goodbye, Silas.", "nextNodeId": "END"} ]
     },
     "silas_artifact_assembly_failure": {
       "id": "silas_artifact_assembly_failure",
-      "npcText": "A pity. It seems the amulet is more complex than it appears, or perhaps some pieces are still missing or damaged beyond repair. It's just a collection of pretty rocks now.",
+      "npcText": "A disaster! The pieces have shattered beyond repair! All that effort... wasted. I suppose not everyone has the delicate touch required for such ancient mechanisms. A true pity.",
       "playerChoices": [
-        { "text": "Unfortunate.", "nextNodeId": "END" }
+        { "text": "A most unfortunate outcome.", "nextNodeId": "END" }
       ]
     },
     "silas_artifact_assembly_skip": {
@@ -837,6 +1005,36 @@
           "nextNodeId": "END"
         }
       ]
+    },
+    "rostova_spyglass_puzzle_success_dialogue": {
+      "id": "rostova_spyglass_puzzle_success_dialogue",
+      "npcText": "Aha! Tucked away under a loose floorboard, you spot it - Captain Rostova's distinctive spyglass! It seems to be in good condition.",
+      "playerChoices": [
+        {
+          "text": "Excellent. Now to return it to her.",
+          "nextNodeId": "END"
+        }
+      ]
+    },
+    "rostova_spyglass_puzzle_failure_dialogue": {
+      "id": "rostova_spyglass_puzzle_failure_dialogue",
+      "npcText": "Despite your best efforts, you can't seem to locate the spyglass here. Perhaps it's truly lost, or somewhere else entirely.",
+      "playerChoices": [
+        {
+          "text": "Unfortunate.",
+          "nextNodeId": "END"
+        }
+      ]
+    },
+    "rostova_spyglass_puzzle_skip_dialogue": {
+      "id": "rostova_spyglass_puzzle_skip_dialogue",
+      "npcText": "You decide to stop searching for now. The clutter is overwhelming.",
+      "playerChoices": [
+        {
+          "text": "Maybe later.",
+          "nextNodeId": "END"
+        }
+      ]
     }
   },
   "npc_esmeralda_valdez": {
@@ -882,7 +1080,10 @@
       "playerChoices": [
         {
           "text": "I am ready to answer.",
-          "effects": [{"type": "TRIGGER_PUZZLE", "puzzleId": "ESMERALDA_MOON_RIDDLE"}]
+          "effects": [
+            {"type": "TRIGGER_PUZZLE", "puzzleId": "ESMERALDA_MOON_RIDDLE"},
+            {"type": "START_QUEST", "questId": "ESMERALDA_INSIGHT_QUEST"}
+          ]
         },
         {
           "text": "My mind is clouded today, another time perhaps.",
@@ -892,9 +1093,12 @@
     },
     "esmeralda_moon_riddle_success": {
       "id": "esmeralda_moon_riddle_success",
-      "npcText": "Impressive, child. Your spirit is keen, like the sliver of a new moon. The path you seek begins to clear. The tides of fortune favor the wise.",
+      "npcText": "Impressive, child. Your spirit is keen, like the sliver of a new moon. The path you seek begins to clear. The tides of fortune favor the wise. With this clarity, perhaps you are ready to understand more about the whispers of the deep.",
       "playerChoices": [
-        {"text": "Thank you, Esmeralda. What now?", "nextNodeId": "ESMERALDA_RIDDLE_1"}
+        {
+          "text": "What whispers do you speak of, Esmeralda?",
+          "nextNodeId": "esmeralda_deeper_lore_1"
+        }
       ]
     },
     "esmeralda_moon_riddle_failure": {
@@ -977,22 +1181,26 @@
         }
       ]
     },
-    "ESMERALDA_RIDDLE_1": {
-      "id": "ESMERALDA_RIDDLE_1",
-      "npcText": "'The Sunken Star' is not a celestial body, but a tavern in a place of bones, where ships go to die. Finnigan's whispers can be heard there if one knows how to listen... or has something of his to offer his restless shade.",
+    "esmeralda_deeper_lore_1": {
+      "id": "esmeralda_deeper_lore_1",
+      "npcText": "The currents speak of an ancient power stirring, a relic of the old gods tied to the very heart of these islands. They say it was shattered, its pieces scattered by a forgotten cataclysm. One who is wise and observant might perceive its echoes.",
       "playerChoices": [
         {
-          "text": "A tavern in a shipwreck graveyard? Thank you, Seer.",
+          "text": "A shattered relic? That sounds significant.",
+          "nextNodeId": "esmeralda_deeper_lore_2"
+        },
+        {
+          "text": "Thank you for this insight, Esmeralda.",
           "nextNodeId": "END"
         }
       ]
     },
-    "ESMERALDA_RIDDLE_2": {
-      "id": "ESMERALDA_RIDDLE_2",
-      "npcText": "Memories are keys that unlock forgotten paths. Finnigan's memory of betrayal, his knowledge of Varkos's secrets... these are the 'key.' Appease his spirit, learn what he knew. Only then will the path to the treasure become clearer.",
+    "esmeralda_deeper_lore_2": {
+      "id": "esmeralda_deeper_lore_2",
+      "npcText": "Indeed. Keep your eyes open, seeker. The world is older and more mysterious than most pirates dream. What you have learned today is but a drop in the ocean of knowledge. Seek wisdom in all things.",
       "playerChoices": [
         {
-          "text": "I understand. I must find his spirit.",
+          "text": "I will. Farewell for now.",
           "nextNodeId": "END"
         }
       ]

--- a/www/data/items.json
+++ b/www/data/items.json
@@ -153,5 +153,37 @@
     "type": "currency_item",
     "value": 100,
     "cursed": true
+  },
+  {
+    "id": "artifact_piece_1_obsidian",
+    "name": "Curved Obsidian Shard",
+    "description": "A shard of volcanic glass, cool to the touch, with faint, almost invisible carvings. It feels ancient.",
+    "icon": "broken_image",
+    "itemImage": "../www/assets/images/items/obsidian_shard_piece_icon.png",
+    "type": "quest_component"
+  },
+  {
+    "id": "artifact_piece_2_coral",
+    "name": "Sun-Bleached Coral Fragment",
+    "description": "A piece of coral, bleached white by the sun and sea. It has an unusual, smooth indentation.",
+    "icon": "filter_vintage",
+    "itemImage": "../www/assets/images/items/coral_fragment_piece_icon.png",
+    "type": "quest_component"
+  },
+  {
+    "id": "artifact_piece_3_pearl",
+    "name": "Humming Pearl",
+    "description": "A lustrous pearl that seems to hum with a faint, internal energy. It feels warm in your palm.",
+    "icon": "lens_blur",
+    "itemImage": "../www/assets/images/items/humming_pearl_piece_icon.png",
+    "type": "quest_component"
+  },
+  {
+    "id": "amulet_sunken_star_complete",
+    "name": "Amulet of the Sunken Star",
+    "description": "The reassembled Amulet of the Sunken Star. It hums with a subtle energy, hinting at forgotten power.",
+    "icon": "auto_awesome",
+    "itemImage": "../www/assets/images/items/amulet_sunken_star_complete_icon.png",
+    "type": "artifact_quest_reward"
   }
 ]

--- a/www/data/npcs.json
+++ b/www/data/npcs.json
@@ -86,7 +86,24 @@
       "x": "80%",
       "y": "80%"
     },
-    "quests": [],
+    "quests": [
+      {
+        "id": "ESMERALDA_INSIGHT_QUEST",
+        "displayName": "Esmeralda's Insight",
+        "description": "Esmeralda the Seer has offered a riddle. Solving it might grant valuable insight or unlock further wisdom from her.",
+        "status": "available",
+        "startDialogueNodeId": "esmeralda_moon_riddle_prompt",
+        "objectives": [
+          { "id": "solve_riddle", "text": "Solve Esmeralda's riddle about the moon.", "isCompleted": false }
+        ],
+        "completionConditions": {
+          "gameStateSet": "esmeralda_moon_riddle_solved"
+        },
+        "rewards": {
+          "xp": 25
+        }
+      }
+    ],
     "companionData": null
   },
   {
@@ -603,7 +620,44 @@
       "x": "30%",
       "y": "30%"
     },
-    "quests": [],
+    "quests": [
+      {
+        "id": "MOREAU_CRIMSON_MAP_QUEST",
+        "displayName": "The Crimson Cipher",
+        "description": "Captain Moreau has a coded message from the Crimson Marauders. Deciphering it might reveal valuable information about their activities or Varkos's hidden treasure.",
+        "status": "available",
+        "startDialogueNodeId": "moreau_cipher_challenge_prompt",
+        "objectives": [
+          { "id": "decipher_message", "text": "Successfully decipher the Crimson Marauders' coded message.", "isCompleted": false }
+        ],
+        "completionConditions": {
+          "gameStateSet": "map_fragment_1_found"
+        },
+        "rewards": {
+          "xp": 75,
+          "standing_moreau": 1
+        }
+      },
+      {
+        "id": "MOREAU_TORTUGA_SPY_QUEST",
+        "displayName": "The Tortuga Rat",
+        "description": "Captain Moreau suspects a spy in Tortuga is leaking information to the Royal Navy. She needs help identifying the culprit from a list of suspects.",
+        "status": "available",
+        "startDialogueNodeId": "moreau_spy_investigation_start",
+        "objectives": [
+          { "id": "identify_spy", "text": "Identify the Royal Navy spy in Tortuga.", "isCompleted": false }
+        ],
+        "completionConditions": {
+          "questOutcome": "spy_identified_correctly"
+        },
+        "failureConditions": {
+          "questOutcome": "spy_identified_incorrectly_or_escaped"
+        },
+        "rewards": {
+          "xp": 100
+        }
+      }
+    ],
     "companionData": null
   },
   {
@@ -618,7 +672,26 @@
       "x": "60%",
       "y": "60%"
     },
-    "quests": [],
+    "quests": [
+      {
+        "id": "SILAS_SUNKEN_STAR_AMULET_QUEST",
+        "displayName": "The Sunken Star Amulet",
+        "description": "Silas Blackwood desires the legendary Amulet of the Sunken Star. He believes you can find its scattered pieces and reassemble it for him.",
+        "status": "available",
+        "startDialogueNodeId": "silas_intro_sunken_star_quest",
+        "objectives": [
+          { "id": "find_obsidian_shard", "text": "Find the Curved Obsidian Shard.", "isCompleted": false },
+          { "id": "find_coral_fragment", "text": "Find the Sun-Bleached Coral Fragment.", "isCompleted": false },
+          { "id": "obtain_humming_pearl", "text": "Obtain the Humming Pearl from Silas.", "isCompleted": false },
+          { "id": "assemble_amulet", "text": "Assemble the Amulet of the Sunken Star.", "isCompleted": false }
+        ],
+        "rewards": {
+          "xp": 200,
+          "gold": 250,
+          "standing_silas": 3
+        }
+      }
+    ],
     "companionData": null
   },
   {

--- a/www/data/pois.json
+++ b/www/data/pois.json
@@ -262,6 +262,12 @@
           "y": "80%"
         },
         "foundMessage": "You recovered a heavy Cannonball."
+      },
+      {
+        "itemId": "artifact_piece_1_obsidian",
+        "position": { "x": "55%", "y": "40%" },
+        "foundMessage": "Wedged between cooling lava rocks, you find a strange Curved Obsidian Shard!",
+        "condition": { "questInProgress": "SILAS_SUNKEN_STAR_AMULET_QUEST", "questObjectiveIncomplete": "find_obsidian_shard" }
       }
     ],
     "actions": [
@@ -307,6 +313,12 @@
           "y": "40%"
         },
         "foundMessage": "A colorful parrot squawks and lands on your shoulder!"
+      },
+      {
+        "itemId": "artifact_piece_2_coral",
+        "position": { "x": "35%", "y": "80%" },
+        "foundMessage": "Half-buried in the sand near an ancient stone, you uncover a Sun-Bleached Coral Fragment.",
+        "condition": { "questInProgress": "SILAS_SUNKEN_STAR_AMULET_QUEST", "questObjectiveIncomplete": "find_coral_fragment" }
       }
     ],
     "actions": [
@@ -1113,7 +1125,8 @@
             "status": "in_progress"
           }
         },
-        "foundMessage": "You start searching the Crow's Nest..."
+        "foundMessage": "You peer into the clutter of the Crow's Nest, looking for anything unusual...",
+        "conditionNotMetMessage": "There's nothing of interest here right now. Perhaps you should speak to Captain Rostova if you're looking for something specific."
       }
     ],
     "actions": [

--- a/www/data/puzzles.json
+++ b/www/data/puzzles.json
@@ -2,13 +2,15 @@
   {
     "id": "ESMERALDA_MOON_RIDDLE",
     "puzzle_type": "RIDDLE",
+    "npcId": "npc_esmeralda_valdez",
     "description": "Esmeralda fixes her gaze upon you, a knowing smile playing on her lips. 'The sea shows many faces, but only one never weeps, though it is always full. What is it?' she asks, her voice a low whisper.",
     "successDialogNodeId": "esmeralda_moon_riddle_success",
     "failureDialogNodeId": "esmeralda_moon_riddle_failure",
     "skipDialogNodeId": "esmeralda_moon_riddle_skip",
     "successEffects": [
       {"type": "SET_GAME_STATE", "variable": "esmeralda_moon_riddle_solved", "value": true},
-      {"type": "UPDATE_PLAYER_STAT", "stat": "wisdom", "change": 1}
+      {"type": "UPDATE_PLAYER_STAT", "stat": "wisdom", "change": 1},
+      {"type": "UPDATE_QUEST_STATUS", "questId": "ESMERALDA_INSIGHT_QUEST", "status": "completed"}
     ],
     "failureEffects": [
       {"type": "UPDATE_PLAYER_STAT", "stat": "standing_esmeralda", "change": -1}
@@ -28,7 +30,8 @@
     "skipDialogNodeId": "moreau_cipher_challenge_skip",
     "successEffects": [
       {"type": "ADD_ITEM", "itemId": "decoded_map_fragment_1"},
-      {"type": "SET_GAME_STATE", "variable": "map_fragment_1_found", "value": true}
+      {"type": "SET_GAME_STATE", "variable": "map_fragment_1_found", "value": true},
+      {"type": "UPDATE_QUEST_STATUS", "questId": "MOREAU_CRIMSON_MAP_QUEST", "status": "completed"}
     ],
     "data": {
       "cipherText": "GSV XLZGH GSZG WRHVXIV ORV RM HRLOVMXV",
@@ -43,16 +46,20 @@
   {
     "id": "TORTUGA_SPY_DEDUCTION",
     "puzzle_type": "LOGIC_DEDUCTION",
+    "npcId": "npc_captain_isabella_moreau",
     "description": "Captain Moreau pulls you aside. 'There's a rat in Tortuga, feeding information to the Royal Navy. I have a few suspects. Help me identify the spy before they compromise my operations.'",
     "successDialogNodeId": "MOREAU_SPY_IDENTIFIED_SUCCESS",
     "failureDialogNodeId": "MOREAU_SPY_IDENTIFIED_FAILURE",
     "successEffects": [
       {"type": "UPDATE_PLAYER_STAT", "stat": "standing_moreau", "change": 2},
-      {"type": "ADD_RESOURCE", "resource": "gold", "amount": 100}
+      {"type": "ADD_RESOURCE", "resource": "gold", "amount": 100},
+      {"type": "UPDATE_QUEST_STATUS", "questId": "MOREAU_TORTUGA_SPY_QUEST", "status": "completed"},
+      {"type": "SET_GAME_STATE", "variable": "tortuga_spy_identified", "value": true}
     ],
     "failureEffects": [
       {"type": "UPDATE_PLAYER_STAT", "stat": "standing_moreau", "change": -1},
-      {"type": "SET_GAME_STATE", "variable": "tortuga_spy_escaped", "value": true}
+      {"type": "SET_GAME_STATE", "variable": "tortuga_spy_escaped", "value": true},
+      {"type": "UPDATE_QUEST_STATUS", "questId": "MOREAU_TORTUGA_SPY_QUEST", "status": "failed"}
     ],
     "data": {
       "suspects": [
@@ -67,32 +74,38 @@
   {
     "id": "ANCIENT_ARTIFACT_ASSEMBLY",
     "puzzle_type": "OBJECT_ASSEMBLY",
+    "npcId": "npc_silas_blackwood",
     "description": "Silas Blackwood presents you with a collection of broken pieces. 'This, my friend, is said to be the Amulet of the Sunken Star. Reassemble it, and its power could be yours... or mine, for a price.'",
     "successDialogNodeId": "silas_artifact_assembly_success",
     "failureDialogNodeId": "silas_artifact_assembly_failure",
     "skipDialogNodeId": "silas_artifact_assembly_skip",
     "successEffects": [
       {"type": "ADD_ITEM", "itemId": "amulet_sunken_star_complete"},
-      {"type": "UPDATE_PLAYER_STAT", "stat": "standing_silas", "change": 1}
+      {"type": "UPDATE_PLAYER_STAT", "stat": "standing_silas", "change": 1},
+      {"type": "UPDATE_QUEST_OBJECTIVE", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "objectiveId": "assemble_amulet", "isCompleted": true},
+      {"type": "UPDATE_QUEST_STATUS", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "status": "completed"}
     ],
     "failureEffects": [
-      {"type": "REMOVE_ITEM", "itemId": "artifact_piece_1"},
-      {"type": "REMOVE_ITEM", "itemId": "artifact_piece_2"},
-      {"type": "SET_GAME_STATE", "variable": "artifact_pieces_broken", "value": true}
+      {"type": "REMOVE_ITEM", "itemId": "artifact_piece_1_obsidian"},
+      {"type": "REMOVE_ITEM", "itemId": "artifact_piece_2_coral"},
+      {"type": "REMOVE_ITEM", "itemId": "artifact_piece_3_pearl"},
+      {"type": "SET_GAME_STATE", "variable": "artifact_pieces_broken_permanently", "value": true},
+      {"type": "UPDATE_QUEST_STATUS", "questId": "SILAS_SUNKEN_STAR_AMULET_QUEST", "status": "failed"}
     ],
     "data": {
       "required_pieces": [
-        {"itemId": "artifact_piece_1", "description": "A curved piece of obsidian with strange carvings."},
-        {"itemId": "artifact_piece_2", "description": "A smooth, sun-bleached coral fragment."},
-        {"itemId": "artifact_piece_3", "description": "A pearl that hums with a faint energy."}
+        {"itemId": "artifact_piece_1_obsidian", "description": "A curved piece of obsidian with strange carvings."},
+        {"itemId": "artifact_piece_2_coral", "description": "A smooth, sun-bleached coral fragment."},
+        {"itemId": "artifact_piece_3_pearl", "description": "A pearl that hums with a faint energy."}
       ],
       "assembly_instructions_hint": "The obsidian forms the backing, the coral fits into its curve, and the pearl sits at the center.",
-      "correct_order_or_configuration": ["artifact_piece_1", "artifact_piece_2", "artifact_piece_3"]
+      "correct_order_or_configuration": ["artifact_piece_1_obsidian", "artifact_piece_2_coral", "artifact_piece_3_pearl"]
     }
   },
   {
     "id": "ROSTOVA_FIND_SPYGLASS_PUZZLE",
     "puzzle_type": "OBSERVATION",
+    "npcId": "npc_elena_rostova",
     "description": "Captain Rostova mentioned she was last enjoying the view from the 'Crow's Nest' at the 'Salty Siren Tavern'. She thinks her spyglass might have rolled under something there.",
     "successDialogNodeId": "rostova_spyglass_puzzle_success_dialogue",
     "failureDialogNodeId": "rostova_spyglass_puzzle_failure_dialogue",


### PR DESCRIPTION
… quest.

For ESMERALDA_MOON_RIDDLE:
- I created ESMERALDA_INSIGHT_QUEST, linking the riddle's start and completion.
- I added new dialogue for Esmeralda, providing richer lore after you solve the riddle.

I developed ANCIENT_ARTIFACT_ASSEMBLY into a multi-stage quest for Silas:
- I defined new quest items: 3 artifact pieces and the completed amulet.
- I created SILAS_SUNKEN_STAR_AMULET_QUEST with multiple objectives.
- I added extensive dialogue for Silas, covering:
  - The quest introduction and clues for the pieces.
  - How he handles the return of pieces and gives the third piece.
  - A conditional trigger for the assembly puzzle.
  - Dialogue after assembly, offering you a choice to sell or keep the amulet.
- I updated the ANCIENT_ARTIFACT_ASSEMBLY puzzle:
  - I set the npcId and specific required_piece item IDs.
  - The effects now update the main quest objectives and status.
- I placed artifact pieces as hidden objects in relevant POIs with conditional visibility.

These changes add significant depth and interactivity to the targeted puzzles, integrating them more fully into NPC narratives and quest lines.